### PR TITLE
Update sentence.

### DIFF
--- a/res/datasets/messages.json
+++ b/res/datasets/messages.json
@@ -17,7 +17,7 @@
   {
     "tag": "no country",
     "messages": [
-      "I don't find a country in your message"
+      "I did not find a country in your message"
     ]
   },
   {


### PR DESCRIPTION
The previous is incorrect English.    Updated to proper English. 