### PR TITLE
Languages: support movies and music in Italian

### DIFF
--- a/language/movies.go
+++ b/language/movies.go
@@ -45,6 +45,10 @@ var (
 			"Acció", "Aventura", "Animació", "Nen", "Comèdia", "Crim", "Documental", "Drama", "Fantasia",
 			"Film-Noir", "Horror", "Musical", "Misteri", "Romanç", "Ciència-ficció", "Thriller", "War", "Western",
 		},
+		"it": {
+			"Azione", "Avventura", "Animazione", "Bambini", "Commedia", "Poliziesco", "Documentario", "Dramma", "Fantasia",
+			"Film-Noir", "Orrore", "Musical", "Mistero", "Romantico", "Fantascienza", "Giallo", "Guerra", "Western",
+		},
 		"nl": {
 			"Actie", "Avontuur", "Animatie", "Kinderen", "Komedie", "Krimi", "Documentaire", "Drama", "Fantasie",
 			"Film-Noir", "Horror", "Musical", "Mysterie", "Romantiek", "Sci-Fi", "Thriller", "Oorlog", "Western",

--- a/language/music.go
+++ b/language/music.go
@@ -31,6 +31,11 @@ var SpotifyKeyword = map[string]SpotifyKeywords{
 		From: "de",
 		On:   "a",
 	},
+	"it": {
+		Play: "suona",
+		From: "da",
+		On:   "a",
+	},
 	"tr": {
 		Play: "Başlat",
 		From: "dan",


### PR DESCRIPTION
- I noticed that the Italian translation was missing from these two files, so I have added the `it` key to `MovieGenres` and `SpotifyKeyword`.